### PR TITLE
mstpd: do not set sbindir to /sbin

### DIFF
--- a/recipes-network/mstpd/mstpd_git.bb
+++ b/recipes-network/mstpd/mstpd_git.bb
@@ -14,8 +14,6 @@ S = "${WORKDIR}/git"
 
 inherit autotools systemd
 
-EXTRA_OECONF = "--sbindir=/sbin"
-
 CFLAGS += " -DPISM_ENABLE_LOG"
 CFLAGS += " -DPRTSM_ENABLE_LOG"
 CFLAGS += " -DPACKET_DEBUG"


### PR DESCRIPTION
Do not set sbindir to /sbin, as /sbin is not a valid location when usrmerge is enabled. Yocto will automatically pass the correct argument, so there is no need to set it at all, therefore drop it.

Fixes the following build error:

```
ERROR: mstpd-git-r0 do_package: QA Issue: mstpd: Files/directories were installed but not shipped in any package:
  /sbin/bridge-stp
  /sbin/mstpctl
  /sbin/mstp_restart
  /sbin/mstpd
Please set FILES such that these items are packaged. Alternatively if they are unneeded, avoid installing them or delete them within do_install. mstpd: 4 installed and not shipped files. [installed-vs-shipped]
```

Fixes: 78b3cbf70532 ("recipes-network: add mstpd package recipe")