### PR TITLE
poed: update recipe to actually build something

### DIFF
--- a/recipes-support/poed/poed_git.bb
+++ b/recipes-support/poed/poed_git.bb
@@ -6,10 +6,44 @@ LIC_FILES_CHKSUM = "file://../LICENSE;md5=175792518e4ac015ab6696d16c4f607e"
 SRCBRANCH = "main"
 SRCREV = "075be47969596c9b76e6c4afede9908c3f08fc03"
 
+DEPENDS = "python3-smbus2"
+RDEPENDS:${PN} = "bash"
+
 SRC_URI = " \
-  git://github.com/dentproject/poed.git;branch=${SRCBRANCH};protocol=https \
+  gitsm://github.com/dentproject/poed.git;branch=${SRCBRANCH};protocol=https \
 "
 
 S = "${WORKDIR}/git/dentos-poe-agent"
 
-DEPENDS = "python3-smbus2"
+do_install:append() {
+   install -d ${D}${systemd_unitdir}/system
+   install -m 0644 ${S}/lib/systemd/system/poed.service ${D}${systemd_unitdir}/system
+
+   install -d ${D}/opt/poeagent/docs/
+   install -m 0644 ${S}/opt/poeagent/docs/Userguide ${D}/opt/poeagent/docs/Userguide
+
+   install -d ${D}/opt/poeagent/platforms/delta/tn48m-poe-r0
+   install -m 0755 ${S}/opt/poeagent/platforms/delta/tn48m-poe-r0/poe_platform.py ${D}/opt/poeagent/platforms/delta/tn48m-poe-r0/poe_platform.py
+
+   install -d ${D}/opt/poeagent/platforms/accton/as4224-52p-r0
+   install -m 0755 ${S}/opt/poeagent/platforms/accton/as4224-52p-r0/poe_platform.py ${D}/opt/poeagent/platforms/accton/as4224-52p-r0/poe_platform.py
+
+   install -d ${D}/opt/poeagent/platforms/accton/as4564-26p-r0
+   install -m 0755 ${S}/opt/poeagent/platforms/accton/as4564-26p-r0/poe_platform.py ${D}/opt/poeagent/platforms/accton/as4564-26p-r0/poe_platform.py
+
+   install -d ${D}/opt/poeagent/drivers
+   install -m 0755 ${S}/opt/poeagent/drivers/poe_driver_pd69200.py ${D}/opt/poeagent/drivers/poe_driver_pd69200.py
+   install -m 0755 ${S}/opt/poeagent/drivers/poe_driver_pd69200_def.py ${D}/opt/poeagent/drivers/poe_driver_pd69200_def.py
+
+   install -d ${D}/opt/poeagent/bin
+   install -m 0755 ${S}/opt/poeagent/bin/poecli.py ${D}/opt/poeagent/bin/poecli.py
+   install -m 0755 ${S}/opt/poeagent/bin/poed.py ${D}/opt/poeagent/bin/poed.py
+
+   install -d ${D}/opt/poeagent/inc
+   install -m 0755 ${S}/opt/poeagent/inc/poe_common.py ${D}/opt/poeagent/inc/poe_common.py
+   install -m 0755 ${S}/opt/poeagent/inc/poe_version.py ${D}/opt/poeagent/inc/poe_version.py
+}
+
+FILES:${PN} += "\
+   ${systemd_system_unitdir}/poed.service \
+   /opt/poeagent/* "


### PR DESCRIPTION
The poed did not actually build anything, causing it generate no packages since there was nothing to package. This later failed the image generation as there was no poed package to install:

```
ERROR: dentos-image-1.0-r0 do_rootfs: Could not invoke dnf. Command '/home/ubuntu/dent/poky/build/tmp/work/delta_tn48m-poky-linux/dentos-image/1.0/recipe-sysroot-native/usr/bin/dnf -v --rpmverbosity=info -y -c /home/ubuntu/dent/poky/build/tmp/work/delta_tn48m-poky-linux/dentos-image/1.0/rootfs/etc/dnf/dnf.conf --setopt=reposdir=/home/ubuntu/dent/poky/build/tmp/work/delta_tn48m-poky-linux/dentos-image/1.0/rootfs/etc/yum.repos.d --installroot=/home/ubuntu/dent/poky/build/tmp/work/delta_tn48m-poky-linux/dentos-image/1.0/rootfs --setopt=logdir=/home/ubuntu/dent/poky/build/tmp/work/delta_tn48m-poky-linux/dentos-image/1.0/temp --repofrompath=oe-repo,/home/ubuntu/dent/poky/build/tmp/work/delta_tn48m-poky-linux/dentos-image/1.0/oe-rootfs-repo --nogpgcheck install packagegroup-core-boot packagegroup-dentos run-postinsts' returned 1: DNF version: 4.21.1
cachedir: /home/ubuntu/dent/poky/build/tmp/work/delta_tn48m-poky-linux/dentos-image/1.0/rootfs/var/cache/dnf Added oe-repo repo from /home/ubuntu/dent/poky/build/tmp/work/delta_tn48m-poky-linux/dentos-image/1.0/oe-rootfs-repo User-Agent: falling back to 'libdnf': could not detect OS or basearch repo: using cache for: oe-repo
oe-repo: using metadata from Thu 21 Aug 2025 07:23:46 AM UTC. --> Starting dependency resolution
--> Finished dependency resolution
Error:
 Problem: conflicting requests
  - nothing provides poed needed by packagegroup-dentos-1.0-r0.delta_tn48m from oe-repo (try to add '--skip-broken' to skip uninstallable packages)
```

Fix this by actually provide a working recipe:

* do checkout including submodules
* add missing dependencies
* actually install files, and install them to the expected locations

[jonas.gorski: split out poed changes, write commit log]